### PR TITLE
Bug fixes for Issue 57

### DIFF
--- a/src/palo_alto_firewall_analyzer/validators/consolidatable_addresses_and_groups.py
+++ b/src/palo_alto_firewall_analyzer/validators/consolidatable_addresses_and_groups.py
@@ -169,8 +169,13 @@ def replace_policy_contents(policies_needing_replacement, address_to_replacement
                     object_policy_dict[translation]['translated-address'], replacements_made = replace_member_contents(object_policy_dict[translation]['translated-address'], address_to_replacement, replacements_made)
                 if object_policy_dict[translation].get('dynamic-ip-and-port', {}).get('translated-address', {}).get('member'):
                     object_policy_dict[translation]['dynamic-ip-and-port']['translated-address']['member'], replacements_made = replace_member_contents(object_policy_dict[translation]['dynamic-ip-and-port']['translated-address']['member'], address_to_replacement, replacements_made)
-                if object_policy_dict[translation].get('static-ip', {}).get('translated-address', {}).get('member'):
+                # when static-ip --> translated-address doesn't have member object, and IP comes directly as string
+                if isinstance(object_policy_dict[translation].get('static-ip', {}).get('translated-address', {}),str):
+                    translatedAddress = object_policy_dict[translation]['static-ip']['translated-address']
+                    object_policy_dict[translation]['static-ip']['translated-address']={'member':translatedAddress}
                     object_policy_dict[translation]['static-ip']['translated-address']['member'], replacements_made = replace_member_contents(object_policy_dict[translation]['static-ip']['translated-address']['member'], address_to_replacement, replacements_made)
+                elif object_policy_dict[translation].get('static-ip', {}).get('translated-address', {}).get('member'):
+                    object_policy_dict[translation]['static-ip']['translated-address']['member'], replacements_made = replace_member_contents(object_policy_dict[translation]['static-ip']['translated-address']['member'], address_to_replacement, replacements_made)                
         text = f"Replace the following Address members in {policy_dg}'s {policy_type} {policy_entry.get('name')}: {sorted([k + ' with ' + v for k, v in replacements_made.items()])}"
         badentries.append(BadEntry(data=[policy_entry, object_policy_dict], text=text, device_group=policy_dg, entry_type=policy_type))
     return badentries

--- a/src/palo_alto_firewall_analyzer/validators/consolidatable_service_and_groups.py
+++ b/src/palo_alto_firewall_analyzer/validators/consolidatable_service_and_groups.py
@@ -140,7 +140,7 @@ def consolidate_service_like_objects(profilepackage, object_type, object_friendl
                 replacements_made[member_to_replace] = service_to_replacement[member_to_replace]
                 object_policy_dict['service'] = service_to_replacement[member_to_replace]
             # If it's a policy with only one member, it'll be parsed as a string, not a list
-            elif isinstance(object_policy_dict['service']['member'], str):
+            elif isinstance(object_policy_dict['service']['member'], str) and object_policy_dict['service']['member'] in service_to_replacement:
                 member_to_replace = object_policy_dict['service']['member']
                 replacements_made[member_to_replace] = service_to_replacement[member_to_replace]
                 object_policy_dict['service']['member'] = service_to_replacement[member_to_replace]


### PR DESCRIPTION
Bug Fix for Issue - https://github.com/moshekaplan/palo_alto_firewall_analyzer/issues/57

Fixes :

- Static-Ip doesn't have nested member object in consolidatable_addresses_and_groups
- Checking if member_to_replace present in service_to_replacement before directly querying dictionary in consolidatable_service_and_groups